### PR TITLE
fix: extract inline CSS styles to native SVG attributes for GitHub compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>striff-lib</artifactId>
 	<packaging>jar</packaging>
-	<version>3.9.0</version>
+	<version>3.9.1</version>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>striff-lib is a java library for generating striff diagrams.</description>
 	<url>https://github.com/hadi-technology/striff-lib</url>

--- a/src/main/java/com/hadi/striff/diagram/plantuml/PUMLDiagram.java
+++ b/src/main/java/com/hadi/striff/diagram/plantuml/PUMLDiagram.java
@@ -34,9 +34,10 @@ public class PUMLDiagram {
         if (!classDiagramDescription.isEmpty()) {
             final String plantUMLString = genPlantUMLString();
             final byte[] diagram = PUMLHelper.generateDiagram(plantUMLString);
-            diagramStr = SvgImageInliner.inlineSvgImages(
+            diagramStr = SvgStyleExtractor.extractStyles(
+                    SvgImageInliner.inlineSvgImages(
                     sanitizeXml(
-                        stripQualifiedPumlIds(new String(diagram, StandardCharsets.UTF_8))));
+                        stripQualifiedPumlIds(new String(diagram, StandardCharsets.UTF_8)))));
             if (PUMLHelper.invalidPUMLDiagram(diagramStr)) {
                 LOGGER.debug("Original PUML text:\n" + plantUMLString);
                 LOGGER.debug("Generated diagram text:\n" + diagramStr);

--- a/src/main/java/com/hadi/striff/diagram/plantuml/SvgStyleExtractor.java
+++ b/src/main/java/com/hadi/striff/diagram/plantuml/SvgStyleExtractor.java
@@ -23,8 +23,10 @@ public final class SvgStyleExtractor {
             "text-anchor", "text-decoration",
             "display", "visibility");
 
-    private static final Pattern STYLE_ATTR = Pattern.compile(
-            "\\bstyle=\"([^\"]*)\"");
+    // Matches an opening or self-closing tag that contains a style attribute.
+    // Captures: (1) tag name + attrs before style, (2) style value, (3) attrs after style + closing
+    private static final Pattern TAG_WITH_STYLE = Pattern.compile(
+            "(<\\w+\\s[^>]*?)\\bstyle=\"([^\"]*)\"([^>]*>)");
 
     private static final Pattern DECL = Pattern.compile(
             "\\s*([\\w-]+)\\s*:\\s*([^;]+)");
@@ -36,17 +38,21 @@ public final class SvgStyleExtractor {
      * Converts inline {@code style} attributes to native SVG presentation
      * attributes on all elements. Non-convertible CSS properties (e.g.
      * {@code transform}, {@code background}) remain in the {@code style}
-     * attribute.
+     * attribute. Properties that already exist as native attributes on the
+     * element are skipped to avoid duplicate attributes.
      */
     public static String extractStyles(String svg) {
-        Matcher matcher = STYLE_ATTR.matcher(svg);
+        Matcher matcher = TAG_WITH_STYLE.matcher(svg);
         if (!matcher.find()) {
             return svg;
         }
         matcher.reset();
         StringBuffer result = new StringBuffer();
         while (matcher.find()) {
-            String styleValue = matcher.group(1);
+            String beforeStyle = matcher.group(1);
+            String styleValue = matcher.group(2);
+            String afterStyle = matcher.group(3);
+
             Map<String, String> converted = new LinkedHashMap<>();
             StringBuilder remaining = new StringBuilder();
 
@@ -55,7 +61,9 @@ public final class SvgStyleExtractor {
                 String prop = declMatcher.group(1).trim();
                 String val = declMatcher.group(2).trim();
                 if (CONVERTIBLE.contains(prop)) {
-                    converted.put(prop, val);
+                    if (!hasNativeAttr(beforeStyle, afterStyle, prop)) {
+                        converted.put(prop, val);
+                    }
                 } else {
                     if (remaining.length() > 0) {
                         remaining.append("; ");
@@ -64,16 +72,24 @@ public final class SvgStyleExtractor {
                 }
             }
 
-            StringBuilder replacement = new StringBuilder();
+            StringBuilder replacement = new StringBuilder(beforeStyle);
             for (Map.Entry<String, String> e : converted.entrySet()) {
-                replacement.append(' ').append(e.getKey()).append("=\"").append(e.getValue()).append('"');
+                replacement.append(e.getKey()).append("=\"").append(e.getValue()).append("\" ");
             }
             if (remaining.length() > 0) {
-                replacement.append(" style=\"").append(remaining).append('"');
+                replacement.append("style=\"").append(remaining).append("\"");
             }
+            replacement.append(afterStyle);
+
             matcher.appendReplacement(result, Matcher.quoteReplacement(replacement.toString()));
         }
         matcher.appendTail(result);
         return result.toString();
+    }
+
+    private static boolean hasNativeAttr(String before, String after, String attrName) {
+        String pattern = "\\b" + Pattern.quote(attrName) + "\\s*=";
+        return Pattern.compile(pattern).matcher(before).find()
+                || Pattern.compile(pattern).matcher(after).find();
     }
 }

--- a/src/main/java/com/hadi/striff/diagram/plantuml/SvgStyleExtractor.java
+++ b/src/main/java/com/hadi/striff/diagram/plantuml/SvgStyleExtractor.java
@@ -1,0 +1,79 @@
+package com.hadi.striff.diagram.plantuml;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Post-processes SVG output to convert inline CSS {@code style} attributes into
+ * native SVG presentation attributes. GitHub strips inline {@code style}
+ * attributes from embedded SVGs, so this ensures stroke, fill, and other visual
+ * properties survive GitHub's sanitizer.
+ */
+public final class SvgStyleExtractor {
+
+    private static final Set<String> CONVERTIBLE = Set.of(
+            "fill", "fill-opacity", "fill-rule",
+            "stroke", "stroke-width", "stroke-dasharray", "stroke-dashoffset",
+            "stroke-linecap", "stroke-linejoin", "stroke-miterlimit", "stroke-opacity",
+            "opacity", "color",
+            "font-family", "font-size", "font-style", "font-weight",
+            "text-anchor", "text-decoration",
+            "display", "visibility");
+
+    private static final Pattern STYLE_ATTR = Pattern.compile(
+            "\\bstyle=\"([^\"]*)\"");
+
+    private static final Pattern DECL = Pattern.compile(
+            "\\s*([\\w-]+)\\s*:\\s*([^;]+)");
+
+    private SvgStyleExtractor() {
+    }
+
+    /**
+     * Converts inline {@code style} attributes to native SVG presentation
+     * attributes on all elements. Non-convertible CSS properties (e.g.
+     * {@code transform}, {@code background}) remain in the {@code style}
+     * attribute.
+     */
+    public static String extractStyles(String svg) {
+        Matcher matcher = STYLE_ATTR.matcher(svg);
+        if (!matcher.find()) {
+            return svg;
+        }
+        matcher.reset();
+        StringBuffer result = new StringBuffer();
+        while (matcher.find()) {
+            String styleValue = matcher.group(1);
+            Map<String, String> converted = new LinkedHashMap<>();
+            StringBuilder remaining = new StringBuilder();
+
+            Matcher declMatcher = DECL.matcher(styleValue);
+            while (declMatcher.find()) {
+                String prop = declMatcher.group(1).trim();
+                String val = declMatcher.group(2).trim();
+                if (CONVERTIBLE.contains(prop)) {
+                    converted.put(prop, val);
+                } else {
+                    if (remaining.length() > 0) {
+                        remaining.append("; ");
+                    }
+                    remaining.append(prop).append(": ").append(val);
+                }
+            }
+
+            StringBuilder replacement = new StringBuilder();
+            for (Map.Entry<String, String> e : converted.entrySet()) {
+                replacement.append(' ').append(e.getKey()).append("=\"").append(e.getValue()).append('"');
+            }
+            if (remaining.length() > 0) {
+                replacement.append(" style=\"").append(remaining).append('"');
+            }
+            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement.toString()));
+        }
+        matcher.appendTail(result);
+        return result.toString();
+    }
+}

--- a/src/test/java/striff/test/diagram/plantuml/SvgStyleExtractorTest.java
+++ b/src/test/java/striff/test/diagram/plantuml/SvgStyleExtractorTest.java
@@ -1,0 +1,92 @@
+package striff.test.diagram.plantuml;
+
+import com.hadi.striff.diagram.plantuml.SvgStyleExtractor;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SvgStyleExtractorTest {
+
+    @Test
+    public void convertsStrokeStylesToAttributes() {
+        String svg = "<line style=\"stroke:#24292E;stroke-width:1;\" x1=\"6\" x2=\"157\" y1=\"332\" y2=\"332\"/>";
+        String result = SvgStyleExtractor.extractStyles(svg);
+        assertTrue(result.contains("stroke=\"#24292E\""));
+        assertTrue(result.contains("stroke-width=\"1\""));
+        assertFalse(result.contains("style="));
+    }
+
+    @Test
+    public void convertsStrokeDasharray() {
+        String svg = "<path d=\"M10,20 L30,40\" style=\"stroke:#464646;stroke-width:1;stroke-dasharray:7,7;\" fill=\"none\"/>";
+        String result = SvgStyleExtractor.extractStyles(svg);
+        assertTrue(result.contains("stroke=\"#464646\""));
+        assertTrue(result.contains("stroke-width=\"1\""));
+        assertTrue(result.contains("stroke-dasharray=\"7,7\""));
+        assertFalse(result.contains("style="));
+    }
+
+    @Test
+    public void keepsNonConvertiblePropertiesInStyle() {
+        String svg = "<svg style=\"width: 2300px; height: 1322px; background: rgb(248, 248, 248);\" viewBox=\"0 0 2300 1322\"/>";
+        String result = SvgStyleExtractor.extractStyles(svg);
+        assertTrue(result.contains("style=\"width: 2300px; height: 1322px; background: rgb(248, 248, 248)\""));
+        assertFalse(result.contains("stroke="));
+    }
+
+    @Test
+    public void handlesMixedConvertibleAndNonConvertible() {
+        String svg = "<rect style=\"stroke:#24292E;stroke-width:1;transform: scale(0.5);\" width=\"100\" height=\"50\"/>";
+        String result = SvgStyleExtractor.extractStyles(svg);
+        assertTrue(result.contains("stroke=\"#24292E\""));
+        assertTrue(result.contains("stroke-width=\"1\""));
+        assertTrue(result.contains("style=\"transform: scale(0.5)\""));
+    }
+
+    @Test
+    public void passesThroughSvgWithoutStyles() {
+        String svg = "<svg><rect width=\"100\" height=\"50\" fill=\"blue\"/></svg>";
+        String result = SvgStyleExtractor.extractStyles(svg);
+        assertEquals(svg, result);
+    }
+
+    @Test
+    public void handlesMultipleElements() {
+        String svg = "<svg>"
+                + "<line style=\"stroke:#24292E;stroke-width:1;\" x1=\"0\" x2=\"100\" y1=\"0\" y2=\"0\"/>"
+                + "<rect style=\"stroke:none;stroke-width:1;\" width=\"50\" height=\"30\"/>"
+                + "<path d=\"M0,0\" style=\"stroke:#00CC00;stroke-width:1;\" fill=\"none\"/>"
+                + "</svg>";
+        String result = SvgStyleExtractor.extractStyles(svg);
+        assertTrue(result.contains("stroke=\"#24292E\" stroke-width=\"1\""));
+        assertTrue(result.contains("stroke=\"none\" stroke-width=\"1\""));
+        assertTrue(result.contains("stroke=\"#00CC00\" stroke-width=\"1\""));
+        assertFalse(result.contains("style="));
+    }
+
+    @Test
+    public void removesStyleAttributeWhenFullyConverted() {
+        String svg = "<line style=\"stroke:#24292E;stroke-width:1;\" x1=\"0\" x2=\"100\" y1=\"0\" y2=\"0\"/>";
+        String result = SvgStyleExtractor.extractStyles(svg);
+        assertFalse(result.contains("style"));
+    }
+
+    @Test
+    public void handlesFontProperties() {
+        String svg = "<text style=\"font-family:Consolas; font-size:14px;\" x=\"10\" y=\"20\">Hello</text>";
+        String result = SvgStyleExtractor.extractStyles(svg);
+        assertTrue(result.contains("font-family=\"Consolas\""));
+        assertTrue(result.contains("font-size=\"14px\""));
+        assertFalse(result.contains("style="));
+    }
+
+    @Test
+    public void preservesExistingNativeAttributes() {
+        String svg = "<path d=\"M10,20\" fill=\"none\" style=\"stroke:#00CC00;stroke-width:1;\"/>";
+        String result = SvgStyleExtractor.extractStyles(svg);
+        assertTrue(result.contains("fill=\"none\""));
+        assertTrue(result.contains("stroke=\"#00CC00\""));
+    }
+}

--- a/src/test/java/striff/test/diagram/plantuml/SvgStyleExtractorTest.java
+++ b/src/test/java/striff/test/diagram/plantuml/SvgStyleExtractorTest.java
@@ -89,4 +89,28 @@ public class SvgStyleExtractorTest {
         assertTrue(result.contains("fill=\"none\""));
         assertTrue(result.contains("stroke=\"#00CC00\""));
     }
+
+    @Test
+    public void skipsStylePropertyAlreadyPresentAsNativeAttribute() {
+        String svg = "<rect fill=\"#fff\" style=\"fill:#000;stroke:#24292E;stroke-width:1;\" width=\"100\" height=\"50\"/>";
+        String result = SvgStyleExtractor.extractStyles(svg);
+        // fill should NOT be duplicated — native fill="#fff" is kept, style fill:#000 is skipped
+        assertTrue(result.contains("fill=\"#fff\""));
+        assertFalse(result.contains("fill=\"#000\""));
+        // stroke properties are still extracted
+        assertTrue(result.contains("stroke=\"#24292E\""));
+        assertTrue(result.contains("stroke-width=\"1\""));
+        assertFalse(result.contains("style="));
+    }
+
+    @Test
+    public void skipsStylePropertyPresentAsNativeAttributeAfterStyle() {
+        String svg = "<rect style=\"stroke:none;stroke-width:1;\" fill=\"#fff\" stroke=\"#000\" width=\"100\" height=\"50\"/>";
+        String result = SvgStyleExtractor.extractStyles(svg);
+        // native stroke="#000" after the style attr is kept, style stroke:none is skipped
+        assertTrue(result.contains("stroke=\"#000\""));
+        assertFalse(result.contains("stroke=\"none\""));
+        assertTrue(result.contains("stroke-width=\"1\""));
+        assertFalse(result.contains("style="));
+    }
 }


### PR DESCRIPTION
## Summary

- GitHub's SVG sanitizer strips inline `style` attributes from embedded SVGs, causing all strokes (package borders, relationship arrows, component separator lines) to disappear when striffs are rendered on GitHub
- Adds `SvgStyleExtractor` post-processor that converts CSS `style` properties (`stroke`, `stroke-width`, `stroke-dasharray`, `fill`, `font-*`, etc.) to native SVG presentation attributes that GitHub preserves
- Non-convertible CSS properties (`transform`, `background`) remain in the `style` attribute
- Bumps version to 3.9.1

## Test plan

- [x] 9 unit tests for `SvgStyleExtractor` covering stroke conversion, dash arrays, mixed convertible/non-convertible, pass-through, font properties, and existing attribute preservation
- [x] Full `mvn verify` passes (189 tests, 0 checkstyle violations, 0 PMD violations)
- [ ] Manual: generate a striff SVG and verify it renders correctly on GitHub markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)