### PR TITLE
feat: expose PUML source, add C# tests, serialization support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>striff-lib</artifactId>
 	<packaging>jar</packaging>
-	<version>3.9.0</version>
+	<version>3.9.1</version>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>striff-lib is a java library for generating striff diagrams.</description>
 	<url>https://github.com/hadi-technology/striff-lib</url>

--- a/src/main/java/com/hadi/striff/StriffLibVersion.java
+++ b/src/main/java/com/hadi/striff/StriffLibVersion.java
@@ -1,0 +1,14 @@
+package com.hadi.striff;
+
+/**
+ * Versioned serialization contract for cached diff payloads shared across
+ * services. Bump this only when the serialized CodeDiff shape becomes
+ * incompatible with previous readers.
+ */
+public final class StriffLibVersion {
+
+    public static final int CODE_DIFF_FORMAT_VERSION = 1;
+
+    private StriffLibVersion() {
+    }
+}

--- a/src/main/java/com/hadi/striff/diagram/StriffDiagram.java
+++ b/src/main/java/com/hadi/striff/diagram/StriffDiagram.java
@@ -29,6 +29,7 @@ public class StriffDiagram {
     private static final Logger LOGGER = LoggerFactory.getLogger(StriffDiagram.class);
     private final Set<String> containedPkgs = new HashSet<>();
     private String svgCode;
+    private String pumlSource;
     private final Set<DiagramComponent> diagramComponents;
     private RelationsMap diagramRels;
     private ChangeSet changeSet;
@@ -48,11 +49,13 @@ public class StriffDiagram {
             skipDiagramGeneration = true;
         }
         if (!skipDiagramGeneration) {
-            this.svgCode = new PUMLDiagram(new PUMLDiagramData(diagramRels, codeDiff.changeSet().addedRelations(),
+            PUMLDiagram pumlDiagram = new PUMLDiagram(new PUMLDiagramData(diagramRels, codeDiff.changeSet().addedRelations(),
                     codeDiff.changeSet().deletedRelations(), diagramDisplay,
                     codeDiff.mergedModel(), codeDiff.changeSet().addedComponents(),
                     codeDiff.changeSet().deletedComponents(), codeDiff.changeSet().modifiedComponents(),
-                    diagramComponents, config.layoutEngine(), config.filesFilter())).svgText();
+                    diagramComponents, config.layoutEngine(), config.filesFilter()));
+            this.svgCode = pumlDiagram.svgText();
+            this.pumlSource = pumlDiagram.pumlSource();
         }
         this.diagramRels = diagramRels;
         this.changeSet = codeDiff.changeSet();
@@ -61,6 +64,14 @@ public class StriffDiagram {
     @JsonIgnore
     public String svg() {
         return this.svgCode;
+    }
+
+    /**
+     * Returns the original PlantUML source used to generate this diagram.
+     */
+    @JsonIgnore
+    public String pumlSource() {
+        return this.pumlSource;
     }
 
     /**

--- a/src/main/java/com/hadi/striff/diagram/plantuml/PUMLDiagram.java
+++ b/src/main/java/com/hadi/striff/diagram/plantuml/PUMLDiagram.java
@@ -146,6 +146,10 @@ public class PUMLDiagram {
         return this.svgText;
     }
 
+    public final String pumlSource() {
+        return this.classDiagramDescription;
+    }
+
     public final int size() {
         return this.size;
     }

--- a/src/test/java/com/hadi/striff/CodeDiffSerializationTest.java
+++ b/src/test/java/com/hadi/striff/CodeDiffSerializationTest.java
@@ -1,0 +1,65 @@
+package com.hadi.striff;
+
+import com.hadi.clarpse.compiler.Lang;
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.compiler.ProjectFiles;
+import com.hadi.striff.parse.CodeDiff;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CodeDiffSerializationTest {
+
+    @Test
+    public void roundTripPreservesComponentsRelationsAndChangeSet() throws Exception {
+        ProjectFiles oldFiles = new ProjectFiles();
+        oldFiles.insertFile(new ProjectFile("/ClassA.java",
+                "package com.sample; public class ClassA { }"));
+
+        ProjectFiles newFiles = new ProjectFiles();
+        newFiles.insertFile(new ProjectFile("/ClassA.java",
+                "package com.sample; public class ClassA { private ClassB b; }"));
+        newFiles.insertFile(new ProjectFile("/ClassB.java",
+                "package com.sample; public class ClassB { }"));
+
+        StriffConfig config = new StriffConfig().setLanguages(Set.of(Lang.JAVA));
+        CodeDiff original = new StriffOperation(oldFiles, newFiles, config).codeDiff();
+        CodeDiff restored = roundTrip(original);
+
+        assertEquals(original.oldModel().size(), restored.oldModel().size());
+        assertEquals(original.newModel().size(), restored.newModel().size());
+        assertEquals(original.mergedModel().size(), restored.mergedModel().size());
+        assertEquals(edgeSet(original), edgeSet(restored));
+        assertEquals(original.changeSet().addedComponents(), restored.changeSet().addedComponents());
+        assertEquals(original.changeSet().deletedComponents(), restored.changeSet().deletedComponents());
+        assertEquals(original.changeSet().modifiedComponents(), restored.changeSet().modifiedComponents());
+        assertEquals(original.changeSet().keyRelationsComponents(), restored.changeSet().keyRelationsComponents());
+        assertTrue(restored.changeSet().addedComponents().contains("com.sample.ClassB"));
+    }
+
+    private static CodeDiff roundTrip(CodeDiff original) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(original);
+        }
+        try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return (CodeDiff) in.readObject();
+        }
+    }
+
+    private static Set<String> edgeSet(CodeDiff diff) {
+        return diff.extractedRels().allRels().stream()
+                .map(rel -> rel.originalComponent().uniqueName()
+                        + "->" + rel.targetComponent().uniqueName()
+                        + ":" + rel.associationType().name())
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/test/java/com/hadi/striff/StriffOperationIntegrationTest.java
+++ b/src/test/java/com/hadi/striff/StriffOperationIntegrationTest.java
@@ -55,6 +55,8 @@ public class StriffOperationIntegrationTest {
 
         // Verify SVG was rendered
         assertNotNull("SVG should be rendered", diagram.svg());
+        assertNotNull("PUML source should be available", diagram.pumlSource());
+        assertTrue("PUML source should contain PlantUML wrappers", diagram.pumlSource().contains("@startuml"));
         assertTrue("SVG should contain ClassB", diagram.svg().contains("ClassB"));
 
         // Verify no compile warnings
@@ -166,6 +168,7 @@ public class StriffOperationIntegrationTest {
 
         // Verify SVG is null (metadata only mode)
         assertNull("SVG should be null in metadata-only mode", diagram.svg());
+        assertNull("PUML source should be null in metadata-only mode", diagram.pumlSource());
 
         // But metadata should still be available
         assertTrue("Expected ClassA in modified components",

--- a/src/test/java/striff/test/model/ExtractedRelationshipsMultiLanguageTest.java
+++ b/src/test/java/striff/test/model/ExtractedRelationshipsMultiLanguageTest.java
@@ -109,6 +109,44 @@ public class ExtractedRelationshipsMultiLanguageTest {
     }
 
     @Test
+    public void csharpRelationshipExtractionCoversCoreTypes() throws Exception {
+        ProjectFiles files = new ProjectFiles();
+        files.insertFile(new ProjectFile("/src/Models.cs",
+                "namespace MyApp.Models {\n"
+                        + "  public class Parent {}\n"
+                        + "  public interface IWorker {}\n"
+                        + "  public class OwnedDependency {}\n"
+                        + "  public class SharedDependency {}\n"
+                        + "  public class CallDependency {}\n"
+                        + "  public class Child : Parent, IWorker {\n"
+                        + "    private OwnedDependency _owned;\n"
+                        + "    public SharedDependency Shared { get; set; }\n"
+                        + "    public Child(OwnedDependency owned, SharedDependency shared) {\n"
+                        + "      _owned = owned;\n"
+                        + "      Shared = shared;\n"
+                        + "    }\n"
+                        + "    public CallDependency Run(CallDependency input) {\n"
+                        + "      return input;\n"
+                        + "    }\n"
+                        + "  }\n"
+                        + "}\n"));
+
+        OOPSourceCodeModel model = compileModel(files, Lang.CSHARP);
+        RelationsMap relations = new ExtractedRelationships(model).result();
+
+        assertRelationExists(relations, model, "MyApp.Models.Child", "MyApp.Models.Parent",
+                DiagramConstants.ComponentAssociation.SPECIALIZATION);
+        assertRelationExists(relations, model, "MyApp.Models.Child", "MyApp.Models.IWorker",
+                DiagramConstants.ComponentAssociation.REALIZATION);
+        assertRelationExists(relations, model, "MyApp.Models.Child", "MyApp.Models.OwnedDependency",
+                DiagramConstants.ComponentAssociation.COMPOSITION);
+        assertRelationExists(relations, model, "MyApp.Models.Child", "MyApp.Models.SharedDependency",
+                DiagramConstants.ComponentAssociation.AGGREGATION);
+        assertRelationExists(relations, model, "MyApp.Models.Child", "MyApp.Models.CallDependency",
+                DiagramConstants.ComponentAssociation.WEAK_ASSOCIATION);
+    }
+
+    @Test
     public void pythonRelationshipExtractionCoversCoreTypes() throws Exception {
         Assume.assumeTrue(NodeRuntime.isNodeAvailable());
         ProjectFiles files = new ProjectFiles();

--- a/src/test/java/striff/test/model/MultiLanguageModifiedComponentDetectionTest.java
+++ b/src/test/java/striff/test/model/MultiLanguageModifiedComponentDetectionTest.java
@@ -36,6 +36,42 @@ public class MultiLanguageModifiedComponentDetectionTest {
             + "}";
 
     @Test
+    public void csharpAddedMethod_showsClassInDiagram() throws Exception {
+        ProjectFiles oldFiles = new ProjectFiles();
+        ProjectFiles newFiles = new ProjectFiles();
+        oldFiles.insertFile(new ProjectFile("/src/Foo.cs",
+                "namespace MyApp {\n"
+                        + "  public class Foo {\n"
+                        + "    public int Run(int value) {\n"
+                        + "      return value + 1;\n"
+                        + "    }\n"
+                        + "  }\n"
+                        + "}\n"));
+        newFiles.insertFile(new ProjectFile("/src/Foo.cs",
+                "namespace MyApp {\n"
+                        + "  public class Foo {\n"
+                        + "    public int Run(int value) {\n"
+                        + "      return value + 1;\n"
+                        + "    }\n"
+                        + "    public int Compute(int a, int b) {\n"
+                        + "      return a + b;\n"
+                        + "    }\n"
+                        + "  }\n"
+                        + "}\n"));
+
+        OOPSourceCodeModel oldModel = compileModel(oldFiles, Lang.CSHARP);
+        OOPSourceCodeModel newModel = compileModel(newFiles, Lang.CSHARP);
+        ChangeSet changeSet = new ChangeSet(oldModel, newModel);
+
+        Assert.assertTrue(changeSet.inAddedComponents("MyApp.Foo.Compute(int, int)"));
+
+        StriffDiagramModel diagramModel = new StriffDiagramModel(new CodeDiff(oldModel, newModel), java.util.Set.of(), false);
+        Assert.assertTrue(diagramModel.diagramCmps().stream()
+                .map(DiagramComponent::uniqueName)
+                .anyMatch(uniqueName -> uniqueName.endsWith(".Foo")));
+    }
+
+    @Test
     public void pythonBodyOnlyMethodChange_marksMethodModifiedAndDisplaysParentClass() throws Exception {
         Assume.assumeTrue(NodeRuntime.isNodeAvailable());
         ProjectFiles oldFiles = new ProjectFiles();


### PR DESCRIPTION
## Summary
- Add `pumlSource()` to `StriffDiagram` and `PUMLDiagram` to access raw PlantUML markup alongside the rendered SVG
- Add C# relationship extraction test and modified component detection test, validating inheritance, realization, composition, aggregation, and weak associations
- Add `StriffLibVersion` with a `CODE_DIFF_FORMAT_VERSION` constant for future-proofing cached diff serialization
- Add `CodeDiffSerializationTest` verifying Java serialization round-trip preserves all `CodeDiff` data
- Bump version to 3.9.1

## Test plan
- [ ] Verify `StriffOperationIntegrationTest` passes (PUML source assertions)
- [ ] Verify `CodeDiffSerializationTest` passes (round-trip serialization)
- [ ] Verify new C# tests in `ExtractedRelationshipsMultiLanguageTest` and `MultiLanguageModifiedComponentDetectionTest` pass
- [ ] Confirm CI pipeline is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)