### PR TITLE
feat: add expandedFiles config for explicit diagram scope expansion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>striff-lib</artifactId>
 	<packaging>jar</packaging>
-	<version>3.9.3</version>
+	<version>3.10.0</version>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>striff-lib is a java library for generating striff diagrams.</description>
 	<url>https://github.com/hadi-technology/striff-lib</url>

--- a/src/main/java/com/hadi/striff/StriffConfig.java
+++ b/src/main/java/com/hadi/striff/StriffConfig.java
@@ -44,6 +44,14 @@ public class StriffConfig {
      * interfaces) so they can appear as gray contextual components in the diagram.
      */
     private boolean resolveContextualComponents = false;
+    /**
+     * Source files whose components are forced into the diagram regardless of
+     * whether they appear in {@link #filesFilter} or in keyRelationsComponents().
+     * Components from these files that are not added/deleted/modified are
+     * rendered as gray contextual. Callers use this to expand diagram scope
+     * explicitly (e.g., for AI review neighborhood components).
+     */
+    private Set<String> expandedFiles = Collections.emptySet();
     private LayoutEngine layoutEngine = LayoutEngine.SMETANA;
     /**
      * Hard limit to avoid sending extremely large diagrams to PlantUML.
@@ -114,6 +122,15 @@ public class StriffConfig {
         return this;
     }
 
+    public StriffConfig setExpandedFiles(final Collection<String> files) {
+        if (files == null) {
+            this.expandedFiles = Collections.emptySet();
+        } else {
+            this.expandedFiles = new HashSet<>(files);
+        }
+        return this;
+    }
+
     public OutputMode outputMode() {
         return this.outputMode;
     }
@@ -136,6 +153,11 @@ public class StriffConfig {
 
     public boolean resolveContextualComponents() {
         return this.resolveContextualComponents;
+    }
+
+    /** Returns source files forced into the diagram as gray contextual components. */
+    public Set<String> expandedFiles() {
+        return this.expandedFiles;
     }
 
     public LayoutEngine layoutEngine() {

--- a/src/main/java/com/hadi/striff/diagram/StriffDiagram.java
+++ b/src/main/java/com/hadi/striff/diagram/StriffDiagram.java
@@ -53,7 +53,7 @@ public class StriffDiagram {
                     codeDiff.changeSet().deletedRelations(), diagramDisplay,
                     codeDiff.mergedModel(), codeDiff.changeSet().addedComponents(),
                     codeDiff.changeSet().deletedComponents(), codeDiff.changeSet().modifiedComponents(),
-                    diagramComponents, config.layoutEngine(), config.filesFilter()));
+                    diagramComponents, config.layoutEngine(), config.filesFilter(), config.expandedFiles()));
             this.svgCode = pumlDiagram.svgText();
             this.pumlSource = pumlDiagram.pumlSource();
         }

--- a/src/main/java/com/hadi/striff/diagram/StriffDiagramModel.java
+++ b/src/main/java/com/hadi/striff/diagram/StriffDiagramModel.java
@@ -39,12 +39,17 @@ public class StriffDiagramModel {
 
     @LogExecutionTime
     public StriffDiagramModel(CodeDiff codeDiff, Set<String> sourceFilesFilter, boolean enableAugmenters) {
+        this(codeDiff, sourceFilesFilter, Collections.emptySet(), enableAugmenters);
+    }
+
+    @LogExecutionTime
+    public StriffDiagramModel(CodeDiff codeDiff, Set<String> sourceFilesFilter, final Set<String> expandedFiles, boolean enableAugmenters) {
         LOGGER.info("Generating diagram model..");
         Set<String> targetCmpNames = codeDiff.mergedModel().components()
                 .filter(cmp -> sourceFilesFilter.contains(cmp.sourceFile())).map(Component::uniqueName)
                 .collect(Collectors.toSet());
         LOGGER.debug("The following components will be analyzed: {}", targetCmpNames);
-        getCoreBaseCmps(codeDiff, sourceFilesFilter).forEach(
+        getCoreBaseCmps(codeDiff, sourceFilesFilter, expandedFiles).forEach(
                 cmpName -> this.diagramCmps.add(new DiagramComponent(
                         cmpName, codeDiff.mergedModel())));
         if (enableAugmenters) {
@@ -60,7 +65,7 @@ public class StriffDiagramModel {
         LOGGER.info(this.diagramRels.size() + " relations will be displayed.");
     }
 
-    private Set<String> getCoreBaseCmps(CodeDiff codeDiff, Set<String> sourceFilesFilter) {
+    private Set<String> getCoreBaseCmps(CodeDiff codeDiff, Set<String> sourceFilesFilter, final Set<String> expandedFiles) {
         LOGGER.info("Selecting diagram components...");
         Set<String> diagramCmpNames = new HashSet<>();
         ChangeSet changeSet = codeDiff.changeSet();
@@ -68,6 +73,15 @@ public class StriffDiagramModel {
                 changeSet.deletedComponents(),
                 changeSet.keyRelationsComponents(),
                 changeSet.modifiedComponents()).flatMap(Collection::stream).collect(Collectors.toSet());
+
+        // Include components from expandedFiles that aren't already in the change set
+        if (!expandedFiles.isEmpty()) {
+            codeDiff.mergedModel().components()
+                    .filter(cmp -> expandedFiles.contains(cmp.sourceFile()))
+                    .map(Component::uniqueName)
+                    .forEach(unfilteredCoreCmps::add);
+        }
+
         if (!sourceFilesFilter.isEmpty()) {
             // Filter added/deleted/modified components by source file
             // But keep keyRelationsComponents (contextual components) - they should appear as gray
@@ -78,9 +92,17 @@ public class StriffDiagramModel {
                         if (keyRels.contains(cmp)) {
                             return true;
                         }
-                        // Other components must be in the source file filter
+                        // Expanded files components are always included
                         var cmpOpt = codeDiff.mergedModel().getComponent(cmp);
-                        return cmpOpt.isPresent() && sourceFilesFilter.contains(cmpOpt.get().sourceFile());
+                        if (cmpOpt.isEmpty()) {
+                            return false;
+                        }
+                        String sourceFile = cmpOpt.get().sourceFile();
+                        if (sourceFile != null && expandedFiles.contains(sourceFile)) {
+                            return true;
+                        }
+                        // Other components must be in the source file filter
+                        return sourceFilesFilter.contains(sourceFile);
                     })
                     .collect(Collectors.toSet());
         }

--- a/src/main/java/com/hadi/striff/diagram/StriffOutput.java
+++ b/src/main/java/com/hadi/striff/diagram/StriffOutput.java
@@ -65,7 +65,7 @@ public class StriffOutput {
             return;
         }
 
-        StriffDiagramModel sDM = new StriffDiagramModel(codeDiff, config.filesFilter(), config.enableAugmenters());
+        StriffDiagramModel sDM = new StriffDiagramModel(codeDiff, config.filesFilter(), config.expandedFiles(), config.enableAugmenters());
         generateDiagrams(codeDiff, sDM.diagramRels(), partitionConfig(sDM, config), config);
         if (config.filesFilter().isEmpty()) {
             compileFailures.forEach(failure -> this.compileWarnings.add(failure.file().path()));

--- a/src/main/java/com/hadi/striff/diagram/plantuml/PUMLClassFieldsCode.java
+++ b/src/main/java/com/hadi/striff/diagram/plantuml/PUMLClassFieldsCode.java
@@ -25,6 +25,7 @@ final class PUMLClassFieldsCode {
     private final Set<String> addedComponents;
     private final Set<String> modifiedComponents;
     private final Set<String> sourceFilesFilter;
+    private final Set<String> expandedFiles;
     private final DiagramDisplay diagramDisplay;
     private final List<ClassDecorator> classDecorators;
     private int commentTextIndex = 1;
@@ -35,6 +36,7 @@ final class PUMLClassFieldsCode {
         this.deletedComponents = data.deletedCmps();
         this.modifiedComponents = data.modifiedCmps();
         this.sourceFilesFilter = data.sourceFilesFilter();
+        this.expandedFiles = data.expandedFiles();
         this.diagramDisplay = data.diagramDisplay();
         this.classDecorators = data.classDecorators();
     }
@@ -384,6 +386,15 @@ final class PUMLClassFieldsCode {
     }
 
     private boolean isContextualComponent(DiagramComponent component) {
+        // Components from expandedFiles that are not added/deleted/modified are contextual (gray)
+        if (!expandedFiles.isEmpty()
+                && component.sourceFile() != null
+                && expandedFiles.contains(component.sourceFile())
+                && !addedComponents.contains(component.uniqueName())
+                && !deletedComponents.contains(component.uniqueName())
+                && !modifiedComponents.contains(component.uniqueName())) {
+            return true;
+        }
         return !sourceFilesFilter.isEmpty()
                 && component.sourceFile() != null
                 && !sourceFilesFilter.contains(component.sourceFile());

--- a/src/main/java/com/hadi/striff/diagram/plantuml/PUMLDiagramData.java
+++ b/src/main/java/com/hadi/striff/diagram/plantuml/PUMLDiagramData.java
@@ -35,7 +35,7 @@ public class PUMLDiagramData {
             DiagramDisplay diagramDisplay, OOPSourceCodeModel mergedModel, Set<String> addedCmps,
             Set<String> deletedCmps, Set<String> modifiedCmps, Set<DiagramComponent> diagramCmps) {
         this(diagramRels, addedRels, deletedRels, diagramDisplay, mergedModel, addedCmps,
-                deletedCmps, modifiedCmps, diagramCmps, LayoutEngine.GRAPHVIZ, Set.of(), Set.of());
+                deletedCmps, modifiedCmps, diagramCmps, LayoutEngine.SMETANA, Set.of(), Set.of());
     }
 
     public PUMLDiagramData(RelationsMap diagramRels, RelationsMap addedRels, RelationsMap deletedRels,

--- a/src/main/java/com/hadi/striff/diagram/plantuml/PUMLDiagramData.java
+++ b/src/main/java/com/hadi/striff/diagram/plantuml/PUMLDiagramData.java
@@ -23,6 +23,7 @@ public class PUMLDiagramData {
     private final Set<String> deletedCmps;
     private final Set<String> modifiedCmps;
     private final Set<String> sourceFilesFilter;
+    private final Set<String> expandedFiles;
     private final Set<DiagramComponent> diagramCmps;
     private final List<ClassDecorator> classDecorators;
     private final List<DiagramDecorator> diagramDecorators;
@@ -34,7 +35,7 @@ public class PUMLDiagramData {
             DiagramDisplay diagramDisplay, OOPSourceCodeModel mergedModel, Set<String> addedCmps,
             Set<String> deletedCmps, Set<String> modifiedCmps, Set<DiagramComponent> diagramCmps) {
         this(diagramRels, addedRels, deletedRels, diagramDisplay, mergedModel, addedCmps,
-                deletedCmps, modifiedCmps, diagramCmps, LayoutEngine.GRAPHVIZ, Set.of());
+                deletedCmps, modifiedCmps, diagramCmps, LayoutEngine.GRAPHVIZ, Set.of(), Set.of());
     }
 
     public PUMLDiagramData(RelationsMap diagramRels, RelationsMap addedRels, RelationsMap deletedRels,
@@ -42,13 +43,21 @@ public class PUMLDiagramData {
             Set<String> deletedCmps, Set<String> modifiedCmps, Set<DiagramComponent> diagramCmps,
             LayoutEngine layoutEngine) {
         this(diagramRels, addedRels, deletedRels, diagramDisplay, mergedModel, addedCmps,
-                deletedCmps, modifiedCmps, diagramCmps, layoutEngine, Set.of());
+                deletedCmps, modifiedCmps, diagramCmps, layoutEngine, Set.of(), Set.of());
     }
 
     public PUMLDiagramData(RelationsMap diagramRels, RelationsMap addedRels, RelationsMap deletedRels,
             DiagramDisplay diagramDisplay, OOPSourceCodeModel mergedModel, Set<String> addedCmps,
             Set<String> deletedCmps, Set<String> modifiedCmps, Set<DiagramComponent> diagramCmps,
             LayoutEngine layoutEngine, Set<String> sourceFilesFilter) {
+        this(diagramRels, addedRels, deletedRels, diagramDisplay, mergedModel, addedCmps,
+                deletedCmps, modifiedCmps, diagramCmps, layoutEngine, sourceFilesFilter, Set.of());
+    }
+
+    public PUMLDiagramData(RelationsMap diagramRels, RelationsMap addedRels, RelationsMap deletedRels,
+            DiagramDisplay diagramDisplay, OOPSourceCodeModel mergedModel, Set<String> addedCmps,
+            Set<String> deletedCmps, Set<String> modifiedCmps, Set<DiagramComponent> diagramCmps,
+            LayoutEngine layoutEngine, Set<String> sourceFilesFilter, final Set<String> exFiles) {
         this.diagramRels = diagramRels;
         this.addedRels = addedRels;
         this.deletedRels = deletedRels;
@@ -61,6 +70,11 @@ public class PUMLDiagramData {
             this.sourceFilesFilter = Set.of();
         } else {
             this.sourceFilesFilter = Set.copyOf(sourceFilesFilter);
+        }
+        if (exFiles == null) {
+            this.expandedFiles = Set.of();
+        } else {
+            this.expandedFiles = Set.copyOf(exFiles);
         }
         this.diagramCmps = diagramCmps;
         this.classDecorators = SpiLoader.loadOrdered(ClassDecorator.class, ClassDecorator::order);
@@ -104,6 +118,11 @@ public class PUMLDiagramData {
 
     public Set<String> sourceFilesFilter() {
         return sourceFilesFilter;
+    }
+
+    /** Returns expanded source files whose components are forced into the diagram. */
+    public Set<String> expandedFiles() {
+        return expandedFiles;
     }
 
     public Set<DiagramComponent> diagramCmps() {


### PR DESCRIPTION
Add StriffConfig.expandedFiles — a set of source files whose components are forced into the diagram regardless of filesFilter or keyRelationsComponents(). Components from expandedFiles that are not added/deleted/modified render as gray contextual, matching existing treatment for out-of-filter key relations.

This unifies with resolveContextualComponents: both produce gray contextual output, but expandedFiles is explicit (caller-specified) while resolveContextualComponents is automatic (parse-time discovery).

Bumps version to 3.10.0.