### PR TITLE
fix: gray contextual components and deduplicate bidirectional arrows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>striff-lib</artifactId>
 	<packaging>jar</packaging>
-	<version>3.9.2</version>
+	<version>3.9.3</version>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>striff-lib is a java library for generating striff diagrams.</description>
 	<url>https://github.com/hadi-technology/striff-lib</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>striff-lib</artifactId>
 	<packaging>jar</packaging>
-	<version>3.9.0</version>
+	<version>3.9.1</version>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>striff-lib is a java library for generating striff diagrams.</description>
 	<url>https://github.com/hadi-technology/striff-lib</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>striff-lib</artifactId>
 	<packaging>jar</packaging>
-	<version>3.9.1</version>
+	<version>3.9.2</version>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>striff-lib is a java library for generating striff diagrams.</description>
 	<url>https://github.com/hadi-technology/striff-lib</url>

--- a/src/main/java/com/hadi/striff/StriffLibVersion.java
+++ b/src/main/java/com/hadi/striff/StriffLibVersion.java
@@ -1,0 +1,14 @@
+package com.hadi.striff;
+
+/**
+ * Versioned serialization contract for cached diff payloads shared across
+ * services. Bump this only when the serialized CodeDiff shape becomes
+ * incompatible with previous readers.
+ */
+public final class StriffLibVersion {
+
+    public static final int CODE_DIFF_FORMAT_VERSION = 1;
+
+    private StriffLibVersion() {
+    }
+}

--- a/src/main/java/com/hadi/striff/diagram/StriffDiagram.java
+++ b/src/main/java/com/hadi/striff/diagram/StriffDiagram.java
@@ -29,6 +29,7 @@ public class StriffDiagram {
     private static final Logger LOGGER = LoggerFactory.getLogger(StriffDiagram.class);
     private final Set<String> containedPkgs = new HashSet<>();
     private String svgCode;
+    private String pumlSource;
     private final Set<DiagramComponent> diagramComponents;
     private RelationsMap diagramRels;
     private ChangeSet changeSet;
@@ -48,11 +49,13 @@ public class StriffDiagram {
             skipDiagramGeneration = true;
         }
         if (!skipDiagramGeneration) {
-            this.svgCode = new PUMLDiagram(new PUMLDiagramData(diagramRels, codeDiff.changeSet().addedRelations(),
+            PUMLDiagram pumlDiagram = new PUMLDiagram(new PUMLDiagramData(diagramRels, codeDiff.changeSet().addedRelations(),
                     codeDiff.changeSet().deletedRelations(), diagramDisplay,
                     codeDiff.mergedModel(), codeDiff.changeSet().addedComponents(),
                     codeDiff.changeSet().deletedComponents(), codeDiff.changeSet().modifiedComponents(),
-                    diagramComponents, config.layoutEngine(), config.filesFilter())).svgText();
+                    diagramComponents, config.layoutEngine(), config.filesFilter()));
+            this.svgCode = pumlDiagram.svgText();
+            this.pumlSource = pumlDiagram.pumlSource();
         }
         this.diagramRels = diagramRels;
         this.changeSet = codeDiff.changeSet();
@@ -61,6 +64,14 @@ public class StriffDiagram {
     @JsonIgnore
     public String svg() {
         return this.svgCode;
+    }
+
+    /**
+     * Returns the original PlantUML source used to generate this diagram.
+     */
+    @JsonIgnore
+    public String pumlSource() {
+        return this.pumlSource;
     }
 
     /**

--- a/src/main/java/com/hadi/striff/diagram/StriffDiagram.java
+++ b/src/main/java/com/hadi/striff/diagram/StriffDiagram.java
@@ -53,7 +53,8 @@ public class StriffDiagram {
                     codeDiff.changeSet().deletedRelations(), diagramDisplay,
                     codeDiff.mergedModel(), codeDiff.changeSet().addedComponents(),
                     codeDiff.changeSet().deletedComponents(), codeDiff.changeSet().modifiedComponents(),
-                    diagramComponents, config.layoutEngine(), config.filesFilter()));
+                    diagramComponents, config.layoutEngine(), config.filesFilter(),
+                    codeDiff.changeSet().keyRelationsComponents()));
             this.svgCode = pumlDiagram.svgText();
             this.pumlSource = pumlDiagram.pumlSource();
         }

--- a/src/main/java/com/hadi/striff/diagram/plantuml/PUMLClassFieldsCode.java
+++ b/src/main/java/com/hadi/striff/diagram/plantuml/PUMLClassFieldsCode.java
@@ -24,6 +24,7 @@ final class PUMLClassFieldsCode {
     private final Set<String> deletedComponents;
     private final Set<String> addedComponents;
     private final Set<String> modifiedComponents;
+    private final Set<String> keyRelationsCmps;
     private final Set<String> sourceFilesFilter;
     private final DiagramDisplay diagramDisplay;
     private final List<ClassDecorator> classDecorators;
@@ -34,6 +35,7 @@ final class PUMLClassFieldsCode {
         this.addedComponents = data.addedCmps();
         this.deletedComponents = data.deletedCmps();
         this.modifiedComponents = data.modifiedCmps();
+        this.keyRelationsCmps = data.keyRelationsCmps();
         this.sourceFilesFilter = data.sourceFilesFilter();
         this.diagramDisplay = data.diagramDisplay();
         this.classDecorators = data.classDecorators();
@@ -384,6 +386,11 @@ final class PUMLClassFieldsCode {
     }
 
     private boolean isContextualComponent(DiagramComponent component) {
+        if (keyRelationsCmps.contains(component.uniqueName())) {
+            return !addedComponents.contains(component.uniqueName())
+                    && !deletedComponents.contains(component.uniqueName())
+                    && !modifiedComponents.contains(component.uniqueName());
+        }
         return !sourceFilesFilter.isEmpty()
                 && component.sourceFile() != null
                 && !sourceFilesFilter.contains(component.sourceFile());

--- a/src/main/java/com/hadi/striff/diagram/plantuml/PUMLClassFieldsCode.java
+++ b/src/main/java/com/hadi/striff/diagram/plantuml/PUMLClassFieldsCode.java
@@ -105,7 +105,8 @@ final class PUMLClassFieldsCode {
             });
             // Group child components into method type and field types
             Set<DiagramComponent> methodChilds = childComponents.stream().filter(
-                    diagramComponent -> diagramComponent.componentType().isMethodComponent())
+                    diagramComponent -> diagramComponent.componentType().isMethodComponent()
+                            || diagramComponent.componentType() == OOPSourceModelConstants.ComponentType.CONSTRUCTOR)
                     .collect(Collectors.toSet());
             Set<DiagramComponent> fieldChilds = childComponents.stream().filter(
                     diagramComponent -> diagramComponent
@@ -206,6 +207,7 @@ final class PUMLClassFieldsCode {
     private String childComponentPUMLText(DiagramComponent childCmp) {
         String childCmpPUMLStr = "";
         if ((childCmp.componentType() == OOPSourceModelConstants.ComponentType.METHOD)
+                || (childCmp.componentType() == OOPSourceModelConstants.ComponentType.CONSTRUCTOR)
                 || (childCmp.componentType() == OOPSourceModelConstants.ComponentType.FUNCTION)
                 || childCmp.componentType().isVariableComponent()) {
             if (!childCmp.componentType().isBaseComponent()) {
@@ -244,11 +246,14 @@ final class PUMLClassFieldsCode {
     private String getChildCmpDisplayText(DiagramComponent childCmp) {
         String childCmpDisplayText = "";
         if (childCmp.componentType().isMethodComponent()
+                || childCmp.componentType() == OOPSourceModelConstants.ComponentType.CONSTRUCTOR
                 || (childCmp.componentType().isVariableComponent()
                         && childCmp.componentType() != OOPSourceModelConstants.ComponentType.ENUM_CONSTANT)) {
             childCmpDisplayText = childCmp.codeFragment();
-            // Truncate long method signatures but preserve return type
-            if (childCmp.componentType().isMethodComponent() && childCmpDisplayText != null) {
+            // Truncate long method/constructor signatures but preserve return type
+            if ((childCmp.componentType().isMethodComponent()
+                    || childCmp.componentType() == OOPSourceModelConstants.ComponentType.CONSTRUCTOR)
+                    && childCmpDisplayText != null) {
                 childCmpDisplayText = truncateMethodSignature(childCmpDisplayText);
             }
         }
@@ -395,8 +400,13 @@ final class PUMLClassFieldsCode {
         int deletedCount = 0;
         int modifiedCount = 0;
 
-        // Count changes among the component's children
+        // Count changes among the component's children (excluding base components like inner classes)
         for (String childName : cmp.children()) {
+            // Skip base components (classes, interfaces, enums) as they are rendered as separate top-level components
+            DiagramComponent childCmp = new DiagramComponent(childName, mergedModel);
+            if (childCmp.componentType().isBaseComponent()) {
+                continue;
+            }
             if (addedComponents.contains(childName)) {
                 addedCount++;
             }

--- a/src/main/java/com/hadi/striff/diagram/plantuml/PUMLClassRelationsCode.java
+++ b/src/main/java/com/hadi/striff/diagram/plantuml/PUMLClassRelationsCode.java
@@ -8,6 +8,7 @@ import com.hadi.striff.extractor.ComponentRelation;
 import com.hadi.striff.extractor.RelationsMap;
 import com.hadi.striff.spi.RelationDecorator;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -36,10 +37,17 @@ final class PUMLClassRelationsCode {
         this.tempStrBuilder = new StringBuilder();
         Set<String> diagramCmpNames = this.diagramComponents.stream().map(DiagramComponent::uniqueName)
                 .collect(Collectors.toSet());
+        Set<String> renderedPairs = new HashSet<>();
         for (DiagramComponent currCmp : this.diagramComponents) {
             for (ComponentRelation currCmpRel : this.diagramRels.significantRels(currCmp.uniqueName())) {
                 // Ensure the relationship involves components from this diagram
                 if (diagramCmpNames.contains(currCmpRel.targetComponent().uniqueName())) {
+                    // Skip if the reverse pair was already rendered
+                    String pair = pairKey(currCmpRel.originalComponent().uniqueName(),
+                            currCmpRel.targetComponent().uniqueName());
+                    if (!renderedPairs.add(pair)) {
+                        continue;
+                    }
                     // Get reverse relation between componentA and component B... this may be empty.
                     ComponentRelation reverseRel = this.diagramRels.mostSignificantRelation(
                             currCmpRel.targetComponent(), currCmpRel.originalComponent());
@@ -148,6 +156,14 @@ final class PUMLClassRelationsCode {
         } else {
             return this.diagramDisplay.colorScheme().classArrowColor();
         }
+    }
+
+    /**
+     * Creates a canonical key for a pair of components so that (A,B) and (B,A)
+     * produce the same key, enabling deduplication of bidirectional arrows.
+     */
+    private String pairKey(String a, String b) {
+        return a.compareTo(b) < 0 ? a + "|" + b : b + "|" + a;
     }
 
     public String value() {

--- a/src/main/java/com/hadi/striff/diagram/plantuml/PUMLDiagram.java
+++ b/src/main/java/com/hadi/striff/diagram/plantuml/PUMLDiagram.java
@@ -146,6 +146,10 @@ public class PUMLDiagram {
         return this.svgText;
     }
 
+    public final String pumlSource() {
+        return this.classDiagramDescription;
+    }
+
     public final int size() {
         return this.size;
     }

--- a/src/main/java/com/hadi/striff/diagram/plantuml/PUMLDiagramData.java
+++ b/src/main/java/com/hadi/striff/diagram/plantuml/PUMLDiagramData.java
@@ -22,6 +22,7 @@ public class PUMLDiagramData {
     private final Set<String> addedCmps;
     private final Set<String> deletedCmps;
     private final Set<String> modifiedCmps;
+    private final Set<String> keyRelationsCmps;
     private final Set<String> sourceFilesFilter;
     private final Set<DiagramComponent> diagramCmps;
     private final List<ClassDecorator> classDecorators;
@@ -34,7 +35,7 @@ public class PUMLDiagramData {
             DiagramDisplay diagramDisplay, OOPSourceCodeModel mergedModel, Set<String> addedCmps,
             Set<String> deletedCmps, Set<String> modifiedCmps, Set<DiagramComponent> diagramCmps) {
         this(diagramRels, addedRels, deletedRels, diagramDisplay, mergedModel, addedCmps,
-                deletedCmps, modifiedCmps, diagramCmps, LayoutEngine.GRAPHVIZ, Set.of());
+                deletedCmps, modifiedCmps, diagramCmps, LayoutEngine.GRAPHVIZ, Set.of(), Set.of());
     }
 
     public PUMLDiagramData(RelationsMap diagramRels, RelationsMap addedRels, RelationsMap deletedRels,
@@ -42,13 +43,13 @@ public class PUMLDiagramData {
             Set<String> deletedCmps, Set<String> modifiedCmps, Set<DiagramComponent> diagramCmps,
             LayoutEngine layoutEngine) {
         this(diagramRels, addedRels, deletedRels, diagramDisplay, mergedModel, addedCmps,
-                deletedCmps, modifiedCmps, diagramCmps, layoutEngine, Set.of());
+                deletedCmps, modifiedCmps, diagramCmps, layoutEngine, Set.of(), Set.of());
     }
 
     public PUMLDiagramData(RelationsMap diagramRels, RelationsMap addedRels, RelationsMap deletedRels,
             DiagramDisplay diagramDisplay, OOPSourceCodeModel mergedModel, Set<String> addedCmps,
             Set<String> deletedCmps, Set<String> modifiedCmps, Set<DiagramComponent> diagramCmps,
-            LayoutEngine layoutEngine, Set<String> sourceFilesFilter) {
+            LayoutEngine layoutEngine, Set<String> sourceFilesFilter, Set<String> keyRelationsCmps) {
         this.diagramRels = diagramRels;
         this.addedRels = addedRels;
         this.deletedRels = deletedRels;
@@ -57,6 +58,7 @@ public class PUMLDiagramData {
         this.addedCmps = addedCmps;
         this.deletedCmps = deletedCmps;
         this.modifiedCmps = modifiedCmps;
+        this.keyRelationsCmps = keyRelationsCmps != null ? Set.copyOf(keyRelationsCmps) : Set.of();
         if (sourceFilesFilter == null) {
             this.sourceFilesFilter = Set.of();
         } else {
@@ -100,6 +102,10 @@ public class PUMLDiagramData {
 
     public Set<String> modifiedCmps() {
         return modifiedCmps;
+    }
+
+    public Set<String> keyRelationsCmps() {
+        return keyRelationsCmps;
     }
 
     public Set<String> sourceFilesFilter() {

--- a/src/test/java/com/hadi/striff/CodeDiffSerializationTest.java
+++ b/src/test/java/com/hadi/striff/CodeDiffSerializationTest.java
@@ -1,0 +1,65 @@
+package com.hadi.striff;
+
+import com.hadi.clarpse.compiler.Lang;
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.compiler.ProjectFiles;
+import com.hadi.striff.parse.CodeDiff;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CodeDiffSerializationTest {
+
+    @Test
+    public void roundTripPreservesComponentsRelationsAndChangeSet() throws Exception {
+        ProjectFiles oldFiles = new ProjectFiles();
+        oldFiles.insertFile(new ProjectFile("/ClassA.java",
+                "package com.sample; public class ClassA { }"));
+
+        ProjectFiles newFiles = new ProjectFiles();
+        newFiles.insertFile(new ProjectFile("/ClassA.java",
+                "package com.sample; public class ClassA { private ClassB b; }"));
+        newFiles.insertFile(new ProjectFile("/ClassB.java",
+                "package com.sample; public class ClassB { }"));
+
+        StriffConfig config = new StriffConfig().setLanguages(Set.of(Lang.JAVA));
+        CodeDiff original = new StriffOperation(oldFiles, newFiles, config).codeDiff();
+        CodeDiff restored = roundTrip(original);
+
+        assertEquals(original.oldModel().size(), restored.oldModel().size());
+        assertEquals(original.newModel().size(), restored.newModel().size());
+        assertEquals(original.mergedModel().size(), restored.mergedModel().size());
+        assertEquals(edgeSet(original), edgeSet(restored));
+        assertEquals(original.changeSet().addedComponents(), restored.changeSet().addedComponents());
+        assertEquals(original.changeSet().deletedComponents(), restored.changeSet().deletedComponents());
+        assertEquals(original.changeSet().modifiedComponents(), restored.changeSet().modifiedComponents());
+        assertEquals(original.changeSet().keyRelationsComponents(), restored.changeSet().keyRelationsComponents());
+        assertTrue(restored.changeSet().addedComponents().contains("com.sample.ClassB"));
+    }
+
+    private static CodeDiff roundTrip(CodeDiff original) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(original);
+        }
+        try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return (CodeDiff) in.readObject();
+        }
+    }
+
+    private static Set<String> edgeSet(CodeDiff diff) {
+        return diff.extractedRels().allRels().stream()
+                .map(rel -> rel.originalComponent().uniqueName()
+                        + "->" + rel.targetComponent().uniqueName()
+                        + ":" + rel.associationType().name())
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/test/java/com/hadi/striff/StriffOperationIntegrationTest.java
+++ b/src/test/java/com/hadi/striff/StriffOperationIntegrationTest.java
@@ -55,6 +55,8 @@ public class StriffOperationIntegrationTest {
 
         // Verify SVG was rendered
         assertNotNull("SVG should be rendered", diagram.svg());
+        assertNotNull("PUML source should be available", diagram.pumlSource());
+        assertTrue("PUML source should contain PlantUML wrappers", diagram.pumlSource().contains("@startuml"));
         assertTrue("SVG should contain ClassB", diagram.svg().contains("ClassB"));
 
         // Verify no compile warnings
@@ -166,6 +168,7 @@ public class StriffOperationIntegrationTest {
 
         // Verify SVG is null (metadata only mode)
         assertNull("SVG should be null in metadata-only mode", diagram.svg());
+        assertNull("PUML source should be null in metadata-only mode", diagram.pumlSource());
 
         // But metadata should still be available
         assertTrue("Expected ClassA in modified components",

--- a/src/test/java/com/hadi/striff/diagram/plantuml/ContextualGrayDemo.java
+++ b/src/test/java/com/hadi/striff/diagram/plantuml/ContextualGrayDemo.java
@@ -60,7 +60,7 @@ public class ContextualGrayDemo {
                 filteredDisplay, codeModel,
                 Set.of(), Set.of(), Set.of(), Set.of(classComponent),
                 LayoutEngine.GRAPHVIZ,
-                Set.of("/OtherFile.java"));  // KEY: sourceFilesFilter parameter
+                Set.of("/OtherFile.java"), Set.of());  // KEY: sourceFilesFilter parameter
         String grayPuml = new PUMLClassFieldsCode(grayData).value(Set.of(classComponent));
 
         System.out.println("\n=== Normal PUML (no filter) ===");

--- a/src/test/java/com/hadi/striff/diagram/plantuml/ContextualGraySvgDemo.java
+++ b/src/test/java/com/hadi/striff/diagram/plantuml/ContextualGraySvgDemo.java
@@ -63,7 +63,7 @@ public class ContextualGraySvgDemo {
                 Set.of(), Set.of(), Set.of(),
                 Set.of(userService, emailService),
                 LayoutEngine.GRAPHVIZ,
-                Set.of("/UserService.java"));  // Filter: only UserService
+                Set.of("/UserService.java"), Set.of());  // Filter: only UserService
 
         // Generate PUML class diagram code
         PUMLClassDiagramCode diagramCode = new PUMLClassDiagramCode(data);

--- a/src/test/java/com/hadi/striff/diagram/plantuml/PUMLClassChangeSummaryTest.java
+++ b/src/test/java/com/hadi/striff/diagram/plantuml/PUMLClassChangeSummaryTest.java
@@ -159,7 +159,8 @@ public class PUMLClassChangeSummaryTest {
                 Set.of(),
                 Set.of(classComponent),
                 LayoutEngine.GRAPHVIZ,
-                Set.of("/Other.java"));
+                Set.of("/Other.java"),
+                Set.of());
 
         String puml = new PUMLClassFieldsCode(data).value(Set.of(classComponent));
         assertTrue(puml.contains("#back:c8c8c8"));

--- a/src/test/java/striff/test/model/ExtractedRelationshipsMultiLanguageTest.java
+++ b/src/test/java/striff/test/model/ExtractedRelationshipsMultiLanguageTest.java
@@ -109,6 +109,44 @@ public class ExtractedRelationshipsMultiLanguageTest {
     }
 
     @Test
+    public void csharpRelationshipExtractionCoversCoreTypes() throws Exception {
+        ProjectFiles files = new ProjectFiles();
+        files.insertFile(new ProjectFile("/src/Models.cs",
+                "namespace MyApp.Models {\n"
+                        + "  public class Parent {}\n"
+                        + "  public interface IWorker {}\n"
+                        + "  public class OwnedDependency {}\n"
+                        + "  public class SharedDependency {}\n"
+                        + "  public class CallDependency {}\n"
+                        + "  public class Child : Parent, IWorker {\n"
+                        + "    private OwnedDependency _owned;\n"
+                        + "    public SharedDependency Shared { get; set; }\n"
+                        + "    public Child(OwnedDependency owned, SharedDependency shared) {\n"
+                        + "      _owned = owned;\n"
+                        + "      Shared = shared;\n"
+                        + "    }\n"
+                        + "    public CallDependency Run(CallDependency input) {\n"
+                        + "      return input;\n"
+                        + "    }\n"
+                        + "  }\n"
+                        + "}\n"));
+
+        OOPSourceCodeModel model = compileModel(files, Lang.CSHARP);
+        RelationsMap relations = new ExtractedRelationships(model).result();
+
+        assertRelationExists(relations, model, "MyApp.Models.Child", "MyApp.Models.Parent",
+                DiagramConstants.ComponentAssociation.SPECIALIZATION);
+        assertRelationExists(relations, model, "MyApp.Models.Child", "MyApp.Models.IWorker",
+                DiagramConstants.ComponentAssociation.REALIZATION);
+        assertRelationExists(relations, model, "MyApp.Models.Child", "MyApp.Models.OwnedDependency",
+                DiagramConstants.ComponentAssociation.COMPOSITION);
+        assertRelationExists(relations, model, "MyApp.Models.Child", "MyApp.Models.SharedDependency",
+                DiagramConstants.ComponentAssociation.AGGREGATION);
+        assertRelationExists(relations, model, "MyApp.Models.Child", "MyApp.Models.CallDependency",
+                DiagramConstants.ComponentAssociation.WEAK_ASSOCIATION);
+    }
+
+    @Test
     public void pythonRelationshipExtractionCoversCoreTypes() throws Exception {
         Assume.assumeTrue(NodeRuntime.isNodeAvailable());
         ProjectFiles files = new ProjectFiles();

--- a/src/test/java/striff/test/model/MultiLanguageModifiedComponentDetectionTest.java
+++ b/src/test/java/striff/test/model/MultiLanguageModifiedComponentDetectionTest.java
@@ -36,6 +36,42 @@ public class MultiLanguageModifiedComponentDetectionTest {
             + "}";
 
     @Test
+    public void csharpAddedMethod_showsClassInDiagram() throws Exception {
+        ProjectFiles oldFiles = new ProjectFiles();
+        ProjectFiles newFiles = new ProjectFiles();
+        oldFiles.insertFile(new ProjectFile("/src/Foo.cs",
+                "namespace MyApp {\n"
+                        + "  public class Foo {\n"
+                        + "    public int Run(int value) {\n"
+                        + "      return value + 1;\n"
+                        + "    }\n"
+                        + "  }\n"
+                        + "}\n"));
+        newFiles.insertFile(new ProjectFile("/src/Foo.cs",
+                "namespace MyApp {\n"
+                        + "  public class Foo {\n"
+                        + "    public int Run(int value) {\n"
+                        + "      return value + 1;\n"
+                        + "    }\n"
+                        + "    public int Compute(int a, int b) {\n"
+                        + "      return a + b;\n"
+                        + "    }\n"
+                        + "  }\n"
+                        + "}\n"));
+
+        OOPSourceCodeModel oldModel = compileModel(oldFiles, Lang.CSHARP);
+        OOPSourceCodeModel newModel = compileModel(newFiles, Lang.CSHARP);
+        ChangeSet changeSet = new ChangeSet(oldModel, newModel);
+
+        Assert.assertTrue(changeSet.inAddedComponents("MyApp.Foo.Compute(int, int)"));
+
+        StriffDiagramModel diagramModel = new StriffDiagramModel(new CodeDiff(oldModel, newModel), java.util.Set.of(), false);
+        Assert.assertTrue(diagramModel.diagramCmps().stream()
+                .map(DiagramComponent::uniqueName)
+                .anyMatch(uniqueName -> uniqueName.endsWith(".Foo")));
+    }
+
+    @Test
     public void pythonBodyOnlyMethodChange_marksMethodModifiedAndDisplaysParentClass() throws Exception {
         Assume.assumeTrue(NodeRuntime.isNodeAvailable());
         ProjectFiles oldFiles = new ProjectFiles();

--- a/src/test/java/striff/test/model/StriffAPITest.java
+++ b/src/test/java/striff/test/model/StriffAPITest.java
@@ -152,6 +152,29 @@ public class StriffAPITest {
 	}
 
 	/**
+	 * SmartTube PR #5797 - Add REST API for remote playback control.
+	 * Base=master, 18 changed files.
+	 */
+	@Ignore
+	@Test
+	public void testSmartTubeRestApi() throws Exception {
+		String baseRepoOwner = "yuliskov";
+		String repoName = "SmartTube";
+		ProjectFiles oldFiles = githubProjectFiles(
+				baseRepoOwner, repoName,
+				"c1bdecbe7064c4a491495bea61cc7f002878511e", Lang.JAVA);
+		ProjectFiles newFiles = githubProjectFiles(
+				baseRepoOwner, repoName, "pull/5797/head", Lang.JAVA);
+		StriffConfig config = new StriffConfig()
+				.setResolveContextualComponents(true);
+		List<StriffDiagram> striffs = new StriffOperation(
+				oldFiles, newFiles, config).result().diagrams();
+		System.out.println("SmartTube #5797 - Total diagrams: "
+				+ striffs.size());
+		writeStriffsToDisk(striffs, "smarttube-5797");
+	}
+
+	/**
 	 * Langchain4j PR #5060 - AI Services: support polymorphic return types.
 	 * Merged PR, base=main, 10 changed files.
 	 */


### PR DESCRIPTION
## Summary
- **Contextual gray fix**: Key relations components (e.g., interfaces referenced by added classes) were not being grayed out when no `sourceFilesFilter` was set. The `isContextualComponent()` check now also consults `keyRelationsComponents` from `ChangeSet`, while excluding added/deleted/modified components to avoid false grays.
- **Duplicate arrow fix**: Bidirectional relations between the same component pair rendered as two separate arrows. Added pair-level deduplication in `PUMLClassRelationsCode` using a canonical pair key.
- Bumps version to 3.9.3.

## Changes
- `PUMLDiagramData`: Added `keyRelationsCmps` field and accessor
- `StriffDiagram`: Passes `keyRelationsComponents` to rendering layer
- `PUMLClassFieldsCode`: `isContextualComponent()` checks `keyRelationsCmps`, excluding added/deleted/modified
- `PUMLClassRelationsCode`: Tracks rendered pairs to skip reverse direction

## Test plan
- [x] All 185 existing tests pass (0 failures)
- [x] SmartTube PR #5797 striff verified: PlaybackView now correctly grayed, no duplicate arrows

🤖 Generated with [Claude Code](https://claude.com/claude-code)