### PR TITLE
fix: deduplicate bidirectional relation arrows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>striff-lib</artifactId>
 	<packaging>jar</packaging>
-	<version>3.10.0</version>
+	<version>3.10.1</version>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>striff-lib is a java library for generating striff diagrams.</description>
 	<url>https://github.com/hadi-technology/striff-lib</url>

--- a/src/main/java/com/hadi/striff/diagram/plantuml/PUMLClassRelationsCode.java
+++ b/src/main/java/com/hadi/striff/diagram/plantuml/PUMLClassRelationsCode.java
@@ -8,6 +8,7 @@ import com.hadi.striff.extractor.ComponentRelation;
 import com.hadi.striff.extractor.RelationsMap;
 import com.hadi.striff.spi.RelationDecorator;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -36,10 +37,17 @@ final class PUMLClassRelationsCode {
         this.tempStrBuilder = new StringBuilder();
         Set<String> diagramCmpNames = this.diagramComponents.stream().map(DiagramComponent::uniqueName)
                 .collect(Collectors.toSet());
+        Set<String> renderedPairs = new HashSet<>();
         for (DiagramComponent currCmp : this.diagramComponents) {
             for (ComponentRelation currCmpRel : this.diagramRels.significantRels(currCmp.uniqueName())) {
                 // Ensure the relationship involves components from this diagram
                 if (diagramCmpNames.contains(currCmpRel.targetComponent().uniqueName())) {
+                    // Skip if the reverse pair was already rendered
+                    String pair = pairKey(currCmpRel.originalComponent().uniqueName(),
+                            currCmpRel.targetComponent().uniqueName());
+                    if (!renderedPairs.add(pair)) {
+                        continue;
+                    }
                     // Get reverse relation between componentA and component B... this may be empty.
                     ComponentRelation reverseRel = this.diagramRels.mostSignificantRelation(
                             currCmpRel.targetComponent(), currCmpRel.originalComponent());
@@ -148,6 +156,10 @@ final class PUMLClassRelationsCode {
         } else {
             return this.diagramDisplay.colorScheme().classArrowColor();
         }
+    }
+
+    private String pairKey(String a, String b) {
+        return a.compareTo(b) < 0 ? a + "|" + b : b + "|" + a;
     }
 
     public String value() {

--- a/src/main/java/com/hadi/striff/diagram/plantuml/PUMLClassRelationsCode.java
+++ b/src/main/java/com/hadi/striff/diagram/plantuml/PUMLClassRelationsCode.java
@@ -159,7 +159,10 @@ final class PUMLClassRelationsCode {
     }
 
     private String pairKey(String a, String b) {
-        return a.compareTo(b) < 0 ? a + "|" + b : b + "|" + a;
+        if (a.compareTo(b) < 0) {
+            return a + "|" + b;
+        }
+        return b + "|" + a;
     }
 
     public String value() {


### PR DESCRIPTION
## Summary
- Bidirectional relations between the same component pair (A→B and B→A) were rendered as two separate arrows, creating visually duplicate connections
- Added pair-level deduplication using a canonical key so only one arrow is drawn per component pair
- Bumps version to 3.10.1

## Test plan
- [x] All 195 tests pass (0 failures)
- [x] Verified with SmartTube PR #5797 striff: no more duplicate arrows between AppPrefs and MediaServiceManager

🤖 Generated with [Claude Code](https://claude.com/claude-code)