### PR TITLE
fix: preserve deterministic direction and diff coloring in pair dedup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>striff-lib</artifactId>
 	<packaging>jar</packaging>
-	<version>3.10.1</version>
+	<version>3.10.2</version>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>striff-lib is a java library for generating striff diagrams.</description>
 	<url>https://github.com/hadi-technology/striff-lib</url>

--- a/src/main/java/com/hadi/striff/diagram/plantuml/PUMLClassRelationsCode.java
+++ b/src/main/java/com/hadi/striff/diagram/plantuml/PUMLClassRelationsCode.java
@@ -42,15 +42,22 @@ final class PUMLClassRelationsCode {
             for (ComponentRelation currCmpRel : this.diagramRels.significantRels(currCmp.uniqueName())) {
                 // Ensure the relationship involves components from this diagram
                 if (diagramCmpNames.contains(currCmpRel.targetComponent().uniqueName())) {
-                    // Skip if the reverse pair was already rendered
-                    String pair = pairKey(currCmpRel.originalComponent().uniqueName(),
-                            currCmpRel.targetComponent().uniqueName());
+                    String source = currCmpRel.originalComponent().uniqueName();
+                    String target = currCmpRel.targetComponent().uniqueName();
+                    String pair = pairKey(source, target);
                     if (!renderedPairs.add(pair)) {
                         continue;
                     }
-                    // Get reverse relation between componentA and component B... this may be empty.
+                    // Get reverse relation to determine preferred direction
                     ComponentRelation reverseRel = this.diagramRels.mostSignificantRelation(
                             currCmpRel.targetComponent(), currCmpRel.originalComponent());
+                    // Prefer rendering the direction with diff coloring (added/deleted).
+                    // If neither has diff, prefer canonical direction (source < target)
+                    // for deterministic output across runs.
+                    if (shouldSkipForReverse(currCmpRel, reverseRel, source, target)) {
+                        renderedPairs.remove(pair);
+                        continue;
+                    }
                     if ((currCmp.name() != null) && ((currCmpRel.targetComponent().name() != null)
                             && !currCmp.uniqueName().contains("(")
                             && !currCmpRel.targetComponent().uniqueName().contains("("))) {
@@ -163,6 +170,31 @@ final class PUMLClassRelationsCode {
             return a + "|" + b;
         }
         return b + "|" + a;
+    }
+
+    /**
+     * Determines whether the current direction should be skipped in favor
+     * of the reverse direction. Prefers the direction with diff coloring
+     * (added/deleted) for accurate change visualization. Falls back to
+     * canonical (alphabetical) ordering for deterministic output.
+     */
+    private boolean shouldSkipForReverse(ComponentRelation currRel, ComponentRelation reverseRel,
+            String source, String target) {
+        boolean reverseExists = reverseRel.associationType()
+                != DiagramConstants.ComponentAssociation.NONE;
+        if (!reverseExists) {
+            return false;
+        }
+        boolean currDiff = addedRels.contains(currRel) || deletedRels.contains(currRel);
+        boolean revDiff = addedRels.contains(reverseRel) || deletedRels.contains(reverseRel);
+        if (currDiff && !revDiff) {
+            return false;
+        }
+        if (!currDiff && revDiff) {
+            return true;
+        }
+        boolean isCanonical = source.compareTo(target) < 0;
+        return !isCanonical;
     }
 
     public String value() {


### PR DESCRIPTION
## Summary
Addresses code review feedback from #52 on the bidirectional arrow deduplication.

The previous pair dedup could:
1. Render arrows in non-deterministic direction (HashSet iteration order varies across runs)
2. Pick the wrong diff color when the reverse direction had the added/deleted change (for equal-strength relations like ASSOCIATION/WEAK_ASSOCIATION)

**Fix**: Added `shouldSkipForReverse()` that prefers the direction with diff coloring (added/deleted) for accurate change visualization, and falls back to canonical (alphabetical) ordering for deterministic output.

Bumps version to 3.10.2.

## Test plan
- [x] All 195 tests pass (0 failures)
- [x] Checkstyle clean
- [x] Full `mvn clean package` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)