### PR TITLE
chore: bump version to 3.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,7 @@
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>striff-lib</artifactId>
 	<packaging>jar</packaging>
-<<<<<<< HEAD
 	<version>3.13.0</version>
-=======
-	<version>3.13.0</version>
->>>>>>> d29e6be (chore: bump version to 3.13.0)
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>striff-lib is a java library for generating striff diagrams.</description>
 	<url>https://github.com/hadi-technology/striff-lib</url>


### PR DESCRIPTION
## Summary
- Bumps version from 3.12.0 to 3.13.0
- Fixes broken pom.xml on master (conflict markers left from bad merge)

## Test plan
- [ ] CI build passes on all Java versions (17, 21, 25)
- [ ] Maven Central publish job succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)