### PR TITLE
chore: bump clarpse 9.7.0 -> 9.8.1, release striff-lib 3.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>striff-lib</artifactId>
 	<packaging>jar</packaging>
-	<version>3.13.0</version>
+	<version>3.14.0</version>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>striff-lib is a java library for generating striff diagrams.</description>
 	<url>https://github.com/hadi-technology/striff-lib</url>
@@ -17,7 +17,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<aspectj.version>1.9.7</aspectj.version>
 		<clarpse.groupId>io.github.hadi-technology</clarpse.groupId>
-		<clarpse.version>9.7.0</clarpse.version>
+		<clarpse.version>9.8.1</clarpse.version>
 	</properties>
 	<licenses>
 		<license>


### PR DESCRIPTION
Bumps the clarpse dependency **9.7.0 → 9.8.1** and releases **striff-lib 3.14.0**.

Picks up:
- clarpse **9.8.0** — bounded Node compiler daemons (default 1 per JVM)
- clarpse **9.8.1** — auto-clean of persisted `ProjectFiles` temp dirs via a JVM-shutdown hook (hadii-tech/clarpse#150)

clarpse's change is **purely additive** (a shutdown-hook backstop; no API change), so striff-lib compiles unchanged — verified locally with `mvn compile` against clarpse 9.8.1.

Unblocks striff-api dropping its direct clarpse `9.8.0` override (which only existed to force the daemon gate ahead of striff-lib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)